### PR TITLE
Update rnencryptor.cpp

### DIFF
--- a/src/rnencryptor.cpp
+++ b/src/rnencryptor.cpp
@@ -1,4 +1,3 @@
-
 #include "rnencryptor.h"
 
 #include <sstream>
@@ -87,8 +86,10 @@ string RNEncryptor::generateIv(int length)
 {
 	AutoSeededRandomPool prng;
 
-	byte iv[length];
-	prng.GenerateBlock(iv, sizeof(iv));
+	byte iv[length + 1];
+	prng.GenerateBlock(iv, length);
+
+        iv[length] = '\0';
 
 	string ivString = string((char *)iv);
 	return ivString;


### PR DESCRIPTION
There is a bug when generating IV. If not setting a '\0' at the end, it gets more bytes then expected. Being verified with RNCryptor on Mac and Windows, it works.
