### PR TITLE
fix a bug in `string RNEncryptor::generateIv(int length)`

### DIFF
--- a/src/rnencryptor.cpp
+++ b/src/rnencryptor.cpp
@@ -86,12 +86,9 @@ string RNEncryptor::generateIv(int length)
 {
 	AutoSeededRandomPool prng;
 
-	byte iv[length + 1];
+	byte iv[length];
 	prng.GenerateBlock(iv, length);
 
-        iv[length] = '\0';
-
-	string ivString = string((char *)iv);
-	return ivString;
+	return string((char *)iv, length);
 }
 


### PR DESCRIPTION
The original code may produce a string shorter than `length`, because
the generated buffer may contain some '\0' bytes.
